### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/CI API to docker.yml
+++ b/.github/workflows/CI API to docker.yml
@@ -21,7 +21,7 @@ jobs:
          aws-region: eu-west-2
 
      - name: Publish to Registry
-       uses: elgohr/Publish-Docker-Github-Action@master
+       uses: elgohr/Publish-Docker-Github-Action@v5
        with:
          name: rmurphy599/cutepredictor:latest
          username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore